### PR TITLE
Merge minimal-core-0.3.3 into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
 # KL Kernel Logic
 
-**KL Kernel Logic is a small deterministic execution substrate designed to run both deterministic and nondeterministic operations under explicit constraints. It does not try to orchestrate. It provides a clean, auditable execution core that higher-level systems can build on.**
+**KL Kernel Logic is a small deterministic execution substrate that separates the definition of an operation from its controlled execution. It does not orchestrate. It provides a clean, auditable execution core that higher-level systems can build on.**
 
 [![PyPI version](https://img.shields.io/pypi/v/kl-kernel-logic.svg)](https://pypi.org/project/kl-kernel-logic/)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-blue)
 ![Status](https://img.shields.io/badge/Status-Alpha-orange)
-[![License](https://img.shields.io/badge/License-MIT-green)](https://github.com/lukaspfisterch/kl-kernel-logic/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
 KL Kernel Logic separates the *definition* of an operation (Psi) from its *execution* (CAEL + Kernel).  
-It gives you a small deterministic core that can run both fully deterministic tasks and nondeterministic ones (including LLM calls) with a clear execution trace.
-
-**What you get:**
-- Declarative operation model (Psi)
-- Deterministic kernel execution with structured traces
-- Versioned envelopes for transport and audit
-- Policy-ready execution bridge (timeouts, effect classes)
-- Examples for deterministic math, system calls, and AI tasks
+It gives you a small execution core that can run both fully deterministic tasks and nondeterministic ones (for example AI calls) with a clear execution trace.
 
 ```bash
 pip install kl-kernel-logic
@@ -38,128 +31,102 @@ trace = cael.execute(psi=psi, task=uppercase, text="Hello KL")
 print(trace.describe())
 ```
 
-**Below you find architecture details, policy model, timeout handling, and design notes.**
-
 ## Table of Contents
+
 - [Overview](#overview)
-- [Use Cases](#use-cases)
 - [Core Concepts](#core-concepts)
 - [Architecture](#architecture)
-- [Features](#features)
-- [Timeout & Multiprocessing](#timeout--multiprocessing)
-- [Policy & Audit](#policy--audit)
+- [Policy and Context](#policy-and-context)
+- [Audit](#audit)
 - [Repository Structure](#repository-structure)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
-- [Quick Example](#quick-example)
-- [Policy Example](#policy-example)
-- [AI/LLM Example](#aillm-example)
 - [Foundations Examples](#foundations-examples)
 - [Tests](#tests)
+- [Theoretical Foundation](#theoretical-foundation)
 - [Roadmap](#roadmap)
-- [FAQ](#faq)
-- [Contributing](#contributing)
 - [License](#license)
 
 ## Overview
 
-KL Kernel Logic provides a minimal but expressive grammar for defining operations (Psi) and executing them under explicit constraints (CAEL). It addresses a gap in modern AI/automation stacks:
+KL Kernel Logic provides a minimal grammar for defining operations (Psi) and executing them under explicit constraints (CAEL). It addresses a simple question:
 
-"How do we ensure reproducible and auditable execution when integrating AI or semi-deterministic components?"
+**How do we make execution transparent and auditable when deterministic and nondeterministic components are mixed?**
 
-KL solves this by:
-- defining operations in a declarative schema
+KL does this by:
+
+- defining operations in a declarative schema (Psi)
 - transporting them via versioned envelopes
-- executing them through a deterministic kernel
-- producing a trace bundle suitable for governance and audit
+- executing them through a small kernel
+- producing structured traces that other systems can inspect and store
 
-The framework imposes no domain-specific semantics. It is a binding layer, designed for system builders, AI platform developers, and engineers who need clarity and operational trust.
-
-## Use Cases
-
-KL is designed for tasks that require controlled execution with transparent audit trails:
-
-### Controlled AI Calls
-- Route LLM requests with full input/output tracing
-- Track nondeterminism explicitly
-- Enforce timeouts and network policies
-
-### Reproducible Computation
-- Scientific workflows
-- Deterministic mathematical operations
-- Testable pipelines
-
-### Governed System Tasks
-- Controlled filesystem or network access
-- Operation-level auditability
-- Policy enforcement before execution
+The framework is domain-neutral. It does not impose business semantics. It is a binding layer for system builders and AI platform engineers.
 
 ## Core Concepts
 
-### Psi (Principle Definition Layer)
-Psi describes the essence of an operation, independent of its technical execution:
+### Psi
 
-- psi_type: fully qualified operation identifier (e.g. "foundations.poisson_1d")
-- domain: logical domain (e.g. "math", "io", "governance")
-- effect: execution characteristic (e.g. "pure", "read", "write", "external", "ai")
-- version: schema version (default "0.3.0")
-- constraints: structured PsiConstraints object for policy anchoring
-- optional description, tags, and metadata
+Psi describes the essence of an operation, independent of its technical implementation:
 
-Psi is immutable and serializable.
+- **psi_type**: fully qualified operation identifier (for example "foundations.poisson_1d")
+- **domain**: logical domain (for example "math", "io", "ai")
+- **effect**: execution characteristic (for example "pure", "read", "io", "external", "ai")
+- **version**: schema version (default "0.3.3")
+- **constraints**: PsiConstraints for policy anchoring
+- optional **description**, **tags**, **metadata**
 
-### Effect Classes
+Psi is immutable and serialisable via `to_dict()`.
 
-KL distinguishes effect classes to describe the nature of an operation:
+### Effect classes
 
-- **pure**: deterministic computation with no side effects
-- **read**: read-only operations (config lookup, data retrieval)
-- **io**: filesystem operations (read/write)
-- **external**: network operations (API calls, external services)
-- **ai**: AI/LLM operations (may be nondeterministic)
+Effect classes describe the nature of the operation:
 
-The `DefaultSafePolicyEngine` evaluates these effects:
-- Allows: `pure`, `read`, `ai`
-- Blocks: `io`, `external`
+- **pure** - deterministic computation without side effects
+- **read** - read-only operations
+- **io** - filesystem or similar side effects
+- **external** - network or remote calls
+- **ai** - AI or model calls that may be nondeterministic
 
-**Important:** The `DefaultSafePolicyEngine` marks `ai` operations as `deterministic=False`. This is critical for audit interpretation and governance reporting, but **does not block execution**. AI operations are allowed by default, but their nondeterministic nature is explicitly tracked in every `PolicyDecision` and `ExecutionTrace` for downstream audit systems.
+The default policy engine uses these effect classes but does not hard-code any domain logic.
 
-This classification enables policy-based control and audit traceability without requiring knowledge of the underlying implementation.
+### PsiEnvelope
 
-### PsiEnvelope (Transport & Meta Layer)
-A versioned, auditable container that carries:
+A PsiEnvelope is a versioned container around a Psi:
 
-- the Psi definition
-- a UUID envelope identifier
-- creation timestamp
-- optional metadata
-- optional signature
+- carries the PsiDefinition
+- adds **envelope_id** (UUID)
+- adds creation **timestamp**
+- optional **metadata** and **signature**
 
-Envelopes form the basis for trace bundling, governance, and audit.
-
-### CAEL (Controlled AI Execution Layer)
-A wrapper providing:
-
-- basic validation
-- envelope creation or enrichment
-- constraint mapping
-- policy evaluation
-- value-safe, exception-capturing execution
-
-CAEL does not execute tasks itself. It delegates to the Kernel.
+Envelopes give you a stable transport and audit container.
 
 ### Kernel
-The lowest-level execution engine. It receives a Psi + envelope + callable, executes the callable, and returns a deterministic ExecutionTrace.
 
-The Kernel is intentionally minimal:
+The Kernel is the lowest-level execution engine. It:
 
-- no business logic
-- no policy logic
-- no orchestration logic
+- receives PsiDefinition, optional PsiEnvelope and a callable task
+- executes the callable exactly once
+- captures any exception as a string
+- measures timing
+- returns an ExecutionTrace
 
-It focuses only on clean execution and structured trace output.
+The kernel does not apply policies and does not orchestrate.
+
+### CAEL
+
+The Controlled AI Execution Layer (CAEL):
+
+- evaluates policies via a PolicyEngine
+- builds or reuses a PsiEnvelope
+- delegates execution to the Kernel
+- records policy decisions in the resulting ExecutionTrace
+- optionally classifies timeouts based on ExecutionContext.policy.timeout_seconds
+
+CAEL is the main entry point for calling the kernel with governance hooks.
 
 ## Architecture
+
+Textual overview:
 
 ```text
 Client / App / Orchestrator
@@ -178,421 +145,214 @@ Client / App / Orchestrator
            +-----------+
                  |
                  v
-      Deterministic Ops / AI Models / External APIs
+        Task / Function / Model
 ```
 
-Each run produces a trace bundle:
+Each run produces a trace that bundles:
 
-```text
-{
-  psi: {...},
-  envelope: {...},
-  execution: {
-      success: true,
-      output: ...,
-      error: null,
-      started_at: "2025-11-29T14:23:45.123Z",
-      finished_at: "2025-11-29T14:23:45.456Z",
-      runtime_ms: 333.0
-  }
-}
-```
+- logical intent (Psi)
+- transport metadata (Envelope)
+- execution outcome and timing (ExecutionTrace)
 
-## Features
+## Policy and Context
 
-- Declarative operation model (Psi)
-- Versioned metadata envelope
-- Deterministic kernel execution
-- Serializable execution traces
-- Policy-ready CAEL layer
-- Clean separation of logic and execution
-- Support for deterministic foundations and semi-deterministic AI tasks
-- Reference implementations and examples included
-- Fully testable and predictable runtime behavior
-
-## Timeout & Multiprocessing
-
-KL 0.3.0 introduces timeout enforcement via multiprocessing. When a timeout is specified, tasks execute in a separate process and are terminated if they exceed the deadline. **If no timeout is active, execution runs in the main process without multiprocessing overhead.**
-
-### Timeout Precedence
-Timeouts are resolved in the following order (highest to lowest priority):
-
-1. **Per-call `timeout_seconds` kwarg** passed to `CAEL.execute()`
-2. **`ExecutionContext.policy.timeout_seconds`** from the request context
-3. **`CAELConfig.default_timeout_seconds`** global configuration
-4. **No timeout** if none of the above are specified
-
-Example:
+KL defines a small policy interface and a default policy engine.
 
 ```python
-from kl_kernel_logic import CAEL, CAELConfig, ExecutionContext, ExecutionPolicy
+from kl_kernel_logic import (
+    PsiDefinition,
+    CAEL, CAELConfig,
+    ExecutionContext, ExecutionPolicy,
+)
+from kl_kernel_logic import PolicyViolationError
 
-cael = CAEL(config=CAELConfig(default_timeout_seconds=10))
-ctx = ExecutionContext(
-    user_id="user1",
-    request_id="req1",
-    policy=ExecutionPolicy(timeout_seconds=5)
+psi = PsiDefinition(
+    psi_type="filesystem.write_example",
+    domain="io",
+    effect="io",
 )
 
-# Per-call kwarg takes precedence: 3 seconds
-trace = cael.execute(psi=psi, task=my_task, ctx=ctx, timeout_seconds=3)
+ctx = ExecutionContext(
+    user_id="user_123",
+    request_id="req_456",
+    policy=ExecutionPolicy(
+        allow_network=False,
+        allow_filesystem=False,
+        timeout_seconds=2.0,
+    ),
+)
+
+cael = CAEL(config=CAELConfig())
+
+try:
+    trace = cael.execute(psi=psi, task=some_io_task, ctx=ctx)
+except PolicyViolationError as exc:
+    print(f"Blocked by {exc.policy_name}: {exc.reason}")
 ```
 
-### Multiprocessing Constraints
-When a timeout is enforced, tasks execute in a separate process using Python's multiprocessing module with spawn context. Spawn is the default on Windows and macOS, and available on Linux. This imposes a pickling constraint:
+The built-in **DefaultSafePolicyEngine**:
 
-Tasks must be defined at module top-level (not as lambdas or nested functions) to be serializable across process boundaries.
+- allows **pure**, **read**, **ai**
+- denies **io**, **external** by default
 
-**Not allowed:**
+Timeout classification is derived from `ExecutionContext.policy.timeout_seconds` and the measured runtime.
+
+## Audit
+
+Audit is built on top of the execution trace.
 
 ```python
-# ❌ Lambda (not picklable)
-cael.execute(psi=psi, task=lambda x: x.upper(), timeout_seconds=5)
+from kl_kernel_logic import Kernel, PsiDefinition, PsiEnvelope
+from kl_kernel_logic import build_audit_report
 
-# ❌ Nested function (not picklable)
-def outer():
-    def inner(x):
-        return x.upper()
-    cael.execute(psi=psi, task=inner, timeout_seconds=5)
+psi = PsiDefinition(
+    psi_type="config.read",
+    domain="config",
+    effect="read",
+)
+
+envelope = PsiEnvelope(psi=psi, version="1.0")
+kernel = Kernel()
+
+trace = kernel.execute(psi=psi, task=lambda: "ok", envelope=envelope)
+report = build_audit_report(trace)
+
+print(report.describe())
 ```
 
-**Allowed:**
+Audit reports are simple, serialisable objects that include:
 
-```python
-# ✅ Module-level function
-def my_task(x: str) -> str:
-    return x.upper()
-
-cael.execute(psi=psi, task=my_task, timeout_seconds=5)
-
-# ✅ Callable class with __call__
-class MyTask:
-    def __call__(self, x: str) -> str:
-        return x.upper()
-
-cael.execute(psi=psi, task=MyTask(), timeout_seconds=5)
-```
-
-**Note:** If no timeout is specified, tasks can be arbitrary callables (including lambdas and nested functions) since they execute in the same process.
-
-### Timeout Behavior
-- On timeout: execution is terminated, `ExecutionTrace.success` is `False`, `ExecutionTrace.error` contains `"TimeoutError: execution exceeded timeout"`
-- The worker process is forcibly terminated after the timeout expires
-- No partial results are returned if the task did not complete
-
-## Policy & Audit
-
-KL 0.3.0 includes a policy engine and audit layer:
-
-- **PolicyEngine Interface**: Extensible policy evaluation via strategy pattern
-- **DefaultSafePolicyEngine**: Effect-based policy evaluation (pure, read, io, external, ai)
-- **ExecutionPolicy**: Optional per-request flags (timeout_seconds, allow_network, allow_filesystem) that can be evaluated by PolicyEngine implementations
-- **Policy Evaluation**: Blocks execution before Kernel if policies are violated
-- **Audit Reports**: Deterministic, JSON-serializable execution records with traces
-- **Envelope Versioning**: PsiEnvelope carries UUID, timestamp, and optional metadata for traceability
-
-Future extensions:
-
-- enriched policy language (capabilities, role-based access)
-- input/output scrubbing and validation schemas
-- signature validation and crypto
-- formalized trace schemas (JSON Schema / OpenAPI)
-- governance connectors (JSONL, NDJSON, SIEM integrations)
+- **run_id**
+- **trace** (from ExecutionTrace.describe())
+- **generated_at**
+- optional **metadata**
 
 ## Repository Structure
 
 ```
 src/kl_kernel_logic/
-    psi.py                # Declarative operation definitions
-    psi_envelope.py       # Versioned transport container
-    kernel.py             # Deterministic execution engine
-    cael.py               # Execution wrapper & policy bridge
-    execution_context.py  # Policy and context types
-    policy.py             # Policy templates and evaluation
-    audit.py              # Audit report builder
-    examples/
+    __init__.py
+    psi.py
+    psi_envelope.py
+    kernel.py
+    cael.py
+    execution_context.py
+    policy.py
+    audit.py
     examples_foundations/
 
 tests/
 docs/
 ```
 
-- **psi.py**: Operation definition layer
-- **psi_envelope.py**: Versioned metadata transport
-- **kernel.py**: Low-level execution
-- **cael.py**: Policy evaluation and constraint handling
-- **execution_context.py**: User and policy context types
-- **policy.py**: PolicyEngine interface and DefaultSafePolicyEngine
-- **audit.py**: Audit report generation from execution traces
-- **examples**: Reference implementations
-- **examples_foundations**: Deterministic mathematical operations (Poisson, trajectory, smoothing)
-- **tests**: Full test coverage
-- **docs**: Architecture and usage guides
+- **psi.py** - PsiDefinition and PsiConstraints
+- **psi_envelope.py** - versioned envelope
+- **kernel.py** - execution kernel and ExecutionTrace
+- **cael.py** - CAEL wrapper and CAELConfig
+- **execution_context.py** - ExecutionContext and ExecutionPolicy
+- **policy.py** - PolicyEngine, PolicyDecision, DefaultSafePolicyEngine
+- **audit.py** - AuditReport and builder
+- **examples_foundations** - deterministic reference operations
 
 ## Installation
 
-### From PyPI (Recommended)
+### From PyPI
 
 ```bash
 pip install kl-kernel-logic
 ```
 
-### From Source (Development)
+### From source
 
 ```bash
 git clone https://github.com/lukaspfisterch/kl-kernel-logic.git
 cd kl-kernel-logic
 
 python -m venv .venv
-# Windows
-.\.venv\Scripts\Activate.ps1
-# Linux/macOS
-source .venv/bin/activate
+# Activate venv as usual
 
 pip install -e .
 ```
 
-### Verify Installation
-
-```bash
-python -c "import kl_kernel_logic; print(kl_kernel_logic.__version__)"
-```
-
-### Run Tests (Development)
-
-```bash
-pytest -q
-```
-
 ## Quick Start
 
-Install and run your first KL operation:
-
-```bash
-# Install
-pip install kl-kernel-logic
-
-# Verify
-python -c "import kl_kernel_logic; print(f'KL v{kl_kernel_logic.__version__} ready!')"
-```
-
-## Quick Example
+Minimal end to end:
 
 ```python
-from kl_kernel_logic import (
-    PsiDefinition, PsiConstraints,
-    PsiEnvelope, CAEL, CAELConfig
-)
+from kl_kernel_logic import PsiDefinition, CAEL, CAELConfig
 
-
-def uppercase(text: str) -> str:
-    return text.upper()
-
+def add(a: int, b: int) -> int:
+    return a + b
 
 psi = PsiDefinition(
-    psi_type="text.transform",
-    domain="text",
+    psi_type="math.add",
+    domain="math",
     effect="pure",
 )
 
 cael = CAEL(config=CAELConfig())
+trace = cael.execute(psi=psi, task=add, a=1, b=2)
 
-trace = cael.execute(
-    psi=psi,
-    task=uppercase,
-    text="Hello World"
-)
-
-print(trace.describe())
+print(trace.output)          # 3
+print(trace.success)         # True
+print(trace.runtime_ms)      # float
+print(trace.psi.describe())  # dict representation
 ```
-
-### Output (simplified)
-
-```text
-{
-  "psi": {...},
-  "envelope": {...},
-  "success": true,
-  "output": "HELLO WORLD",
-  "error": null,
-  "runtime_ms": 0.123,
-  "metadata": {}
-}
-```
-
-## Policy Example
-
-KL 0.3.0 uses the PolicyEngine pattern for extensible policy evaluation:
-
-```python
-from kl_kernel_logic import (
-    PsiDefinition,
-    CAEL, CAELConfig,
-    PolicyViolationError
-)
-from kl_kernel_logic.policy import DefaultSafePolicyEngine
-
-# Define an I/O operation
-psi_io = PsiDefinition(
-    psi_type="filesystem.write",
-    domain="io",
-    effect="io",  # Will be blocked by DefaultSafePolicyEngine
-)
-
-# CAEL uses DefaultSafePolicyEngine by default
-cael = CAEL()
-
-try:
-    trace = cael.execute(psi=psi_io, task=write_file)
-except PolicyViolationError as e:
-    print(f"Blocked by {e.policy_name}: {e.reason}")
-```
-
-Run the foundation examples:
-
-```bash
-python -m kl_kernel_logic.examples_foundations.runners
-```
-
-## AI/LLM Example
-
-Execute LLM calls with full governance and audit trail:
-
-```python
-from kl_kernel_logic import (
-    CAEL,
-    PsiDefinition,
-    ExecutionContext,
-    ExecutionPolicy
-)
-import anthropic  # pip install anthropic
-
-def call_claude(prompt: str) -> str:
-    """Simple Claude API wrapper."""
-    client = anthropic.Anthropic()
-    message = client.messages.create(
-        model="claude-sonnet-4-20250514",
-        max_tokens=1024,
-        messages=[{"role": "user", "content": prompt}]
-    )
-    return message.content[0].text
-
-# Define the operation
-psi = PsiDefinition(
-    psi_type="llm.anthropic.completion",
-    domain="ai",
-    effect="ai",  # Marks as AI operation
-    description="Claude AI completion"
-)
-
-# Execution context with user identity and policy
-ctx = ExecutionContext(
-    user_id="user_123",
-    request_id="req_456",
-    policy=ExecutionPolicy(
-        timeout_seconds=30,
-        allow_network=True
-    )
-)
-
-# Execute with full audit trail
-cael = CAEL()
-trace = cael.execute(
-    psi=psi,
-    task=call_claude,
-    ctx=ctx,
-    prompt="Explain quantum computing in simple terms"
-)
-
-# Audit information available
-print(f"User: {trace.envelope.metadata['user_id']}")
-print(f"Started: {trace.started_at}")
-print(f"Runtime: {trace.runtime_ms}ms")
-print(f"Success: {trace.success}")
-if trace.success:
-    print(f"Response: {trace.output[:100]}...")
-```
-
-**Output:**
-```
-User: user_123
-Started: 2025-11-29T15:30:45.123Z
-Runtime: 2341.5ms
-Success: True
-Response: Quantum computing is a revolutionary approach to computation that harnesses the principles...
-```
-
-Every LLM call is:
-- ✅ Logged with user identity
-- ✅ Timed and traced
-- ✅ Policy-controlled (timeout, network access)
-- ✅ Auditable for compliance
 
 ## Foundations Examples
 
-Location: `src/kl_kernel_logic/examples_foundations/`
+The `examples_foundations` module contains deterministic operations such as:
 
-Contains deterministic operations such as:
-
-- Poisson equation solver (1D)
+- Poisson equation solver in 1D
 - Sliding-window smoothing
-- Simple measurement integration
+- Simple trajectory integration
 
-These examples demonstrate:
-
-- reproducibility
-- effect classes (single-step, multi-step, deterministic)
-- usage of Psi and CAEL without AI dependencies
+They are used in the test suite and serve as reference operations.
 
 ## Tests
 
-Execute the suite:
+Run all tests:
 
 ```bash
-pytest -q
+pytest
 ```
 
-Validates:
+The suite covers:
 
-- Psi semantics
-- envelope structure
-- kernel execution correctness
-- CAEL envelope handling and metadata merging
-- deterministic foundation operations
-- policy engine evaluation
+- Psi semantics and constraints
+- envelope behaviour
+- kernel execution and trace structure
+- CAEL policy bridge
+- audit report generation
+- foundation operations
+
+## Theoretical Foundation
+
+KL Kernel Logic is informed by a small execution theory that defines:
+
+- **Δ** (atomic transitions)
+- **V** (behaviour sequences)
+- **t** (logical time)
+- **G** (governance)
+- **L** (boundaries)
+
+A separate document describes how these axioms map to the implementation:
+
+**[docs/execution_theory_in_code.md](docs/execution_theory_in_code.md)**
 
 ## Roadmap
 
-### v0.4.0
-- Extended `PolicyEngine` interface (access to envelope + context)
-- JSONL/NDJSON trace export
-- Trace schema validation (JSON Schema)
-- `PsiConstraints` validation in CAEL (opt-in)
+The alpha versions focus on:
 
-"Future considerations"
+- keeping the core small and stable
+- preserving clear public contracts
+- providing reference examples for deterministic operations
 
-## FAQ
+Future work will explore:
 
-**Q: Is KL production-ready?**  
-A: KL is designed for production-style deterministic execution, but still in alpha to refine scope and API shape. Status "alpha" refers to the limited feature scope, not to stability.
-
-**Q: Does KL work with any LLM provider?**  
-A: Yes. KL is provider-agnostic. Write a simple wrapper function for any API (Anthropic, OpenAI, Azure, local models) and execute it via `CAEL.execute()`.
-
-**Q: What's the performance overhead?**  
-A: Minimal. Core execution adds ~1-2ms. Multiprocessing timeout adds ~50-100ms for process spawn.
-
-**Q: Can I use KL without AI/LLMs?**  
-A: Absolutely. KL works for any operation requiring governance: system calls, database operations, API calls, mathematical computations.
-
-**Q: How do I implement custom policies?**  
-A: Implement the `PolicyEngine` interface. See `DefaultSafePolicyEngine` in `policy.py` as reference.
-
-**Q: Can I disable policy enforcement?**  
-A: You can inject a permissive `PolicyEngine` that allows everything, but this is not recommended.
-
-**Q: Can I use KL in closed-source/commercial projects?**  
-A: Yes. MIT License permits commercial use without restrictions.
+- richer policy evaluation over full trace sequences
+- standardised trace formats (for example JSONL)
+- optional helpers for AI / model execution
 
 ## Contributing
 
@@ -608,6 +368,6 @@ For bug reports and feature requests, please use the [GitHub Issues](https://git
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT License. See [LICENSE](LICENSE) for details.
 
 Copyright (c) 2025 Lukas Pfister

--- a/docs/execution_theory_in_code.md
+++ b/docs/execution_theory_in_code.md
@@ -1,0 +1,395 @@
+# Execution Theory in Code
+
+This document maps the abstract axioms from **[KL Execution Theory](https://github.com/lukaspfisterch/kl-execution-theory)** to concrete constructs in KL Kernel Logic.
+
+The goal is to demonstrate that KL Kernel Logic is not an arbitrary design, but a direct implementation of a minimal, domain-neutral execution model.
+
+---
+
+## Overview
+
+**KL Execution Theory** defines five axioms:
+
+1. **Δ (Delta)** - Atomic state transitions
+2. **V (Behaviour)** - Ordered sequence of transitions
+3. **t (Time)** - Logical time as index
+4. **G (Governance)** - Derived policy evaluation
+5. **L (Boundaries)** - Derived constraint geometry
+
+**KL Kernel Logic** implements these as Python constructs:
+
+| Axiom | Code Manifestation |
+|-------|-------------------|
+| Δ | `Kernel.execute()` call |
+| V | Sequence of `ExecutionTrace` objects |
+| t | `runtime_ms`, `started_at`, `finished_at` |
+| G | `PolicyEngine.evaluate()` + `PolicyDecision` |
+| L | `ExecutionPolicy` + `DefaultSafePolicyEngine` |
+
+---
+
+## 1. Δ (Atomic State Transition)
+
+### Theory
+
+From `axioms/01_delta.md`:
+
+```
+Δ : S → S
+
+A Delta is an indivisible mapping between states.
+- Atomic (no observable substructure)
+- Deterministic (same input → same output)
+- No side channels (no hidden state, randomness, or time dependencies)
+```
+
+### Implementation
+
+In KL Kernel Logic, **one Delta = one `Kernel.execute()` call**.
+
+```python
+from kl_kernel_logic import Kernel, PsiDefinition
+
+def uppercase(text: str) -> str:
+    return text.upper()
+
+psi = PsiDefinition(
+    psi_type="text.uppercase",
+    domain="text",
+    effect="pure"
+)
+
+kernel = Kernel()
+trace = kernel.execute(psi=psi, task=uppercase, text="hello")
+# This entire execution is one Δ
+```
+
+**Properties preserved:**
+
+- **Atomicity**: The kernel executes the task once, captures the result, and returns a complete trace. No partial states are observable.
+- **Determinism**: Same `psi` + same `task` + same `kwargs` → same `output` (for deterministic tasks).
+- **No side channels**: The kernel does not inject randomness, time-dependent logic, or hidden global state into the execution. External dependencies must be explicit in `kwargs`.
+
+---
+
+## 2. V (Behaviour)
+
+### Theory
+
+From `axioms/02_behavior.md`:
+
+```
+V = { Δ₀, Δ₁, Δ₂, …, Δₙ }
+
+Behaviour is the ordered sequence of all executed Deltas.
+- Total order (no branching, no concurrency)
+- Complete (all transitions are in V)
+- Sequential determinism (entire sequence is deterministic)
+```
+
+### Implementation
+
+In KL, behaviour is **a list of `ExecutionTrace` objects** produced by sequential kernel calls.
+
+```python
+from kl_kernel_logic import Kernel, PsiDefinition
+
+kernel = Kernel()
+
+# V - behaviour sequence
+traces = []
+
+# Δ₀
+trace_0 = kernel.execute(psi=psi_add, task=add, a=1, b=2)
+traces.append(trace_0)
+
+# Δ₁
+trace_1 = kernel.execute(psi=psi_multiply, task=multiply, a=trace_0.output, b=3)
+traces.append(trace_1)
+
+# Δ₂
+trace_2 = kernel.execute(psi=psi_format, task=format_result, value=trace_1.output)
+traces.append(trace_2)
+
+# traces is now V = { Δ₀, Δ₁, Δ₂ }
+```
+
+**Properties preserved:**
+
+- **Total order**: Each trace has an implicit index in the list. The list itself defines the order.
+- **Completeness**: All executed operations are captured as traces. Nothing is hidden.
+- **Sequential determinism**: Given the same initial state and same sequence of operations, the resulting `traces` list is identical.
+
+---
+
+## 3. t (Logical Time)
+
+### Theory
+
+From `axioms/03_time.md`:
+
+```
+t = index(V)
+
+Time is not physical. It is the position of a Delta in the sequence V.
+- Derived from behaviour (not fundamental)
+- Discrete (integer indices)
+- Order-preserving (i < j means Δᵢ happens before Δⱼ)
+```
+
+### Implementation
+
+In KL, logical time is represented by:
+
+1. **Index in the trace list** - position in V
+2. **`started_at` / `finished_at`** - RFC 3339 timestamps (for human audit)
+3. **`runtime_ms`** - duration of single Δ (for performance analysis)
+
+```python
+# Logical time = index
+for t, trace in enumerate(traces):
+    print(f"t={t}: {trace.psi.psi_type}")
+    print(f"  Started:  {trace.started_at}")
+    print(f"  Finished: {trace.finished_at}")
+    print(f"  Runtime:  {trace.runtime_ms}ms")
+```
+
+**Properties preserved:**
+
+- **Derived**: Time only exists through execution. No execution → no time.
+- **Discrete**: Each trace has a distinct index `t`.
+- **Order-preserving**: If `t_i < t_j`, then `traces[t_i]` executed before `traces[t_j]`.
+
+**Important**: The RFC 3339 timestamps (`started_at`, `finished_at`) are **metadata for human audit**. They are not part of the logical time model. Logical time is purely structural (index-based).
+
+---
+
+## 4. G (Governance)
+
+### Theory
+
+From `axioms/04_governance.md`:
+
+```
+G = f(V)
+
+Governance is a function over behaviour.
+- Non-executing (does not modify V)
+- Behaviour-derived (depends only on V)
+- Deterministic evaluation (same V → same decision)
+- Domain-neutral (structure, not semantics)
+```
+
+### Implementation
+
+In KL, governance is implemented through the **`PolicyEngine` interface**.
+
+```python
+from kl_kernel_logic import PolicyEngine, PolicyDecision, PsiDefinition
+
+class DefaultSafePolicyEngine(PolicyEngine):
+    def evaluate(self, psi: PsiDefinition) -> PolicyDecision:
+        effect = (psi.effect or "").strip().lower()
+        policy_name = "default_safe_policy"
+
+        if effect in {"pure", "read", "ai"}:
+            return PolicyDecision(
+                policy_name=policy_name,
+                allowed=True,
+                reason=f"effect '{effect}' is allowed"
+            )
+
+        return PolicyDecision(
+            policy_name=policy_name,
+            allowed=False,
+            reason=f"effect '{effect}' is not allowed"
+        )
+```
+
+**Properties preserved:**
+
+- **Non-executing**: `PolicyEngine.evaluate()` does not execute the task. It only inspects the `PsiDefinition` and returns a decision.
+- **Behaviour-derived**: The decision is based on observable properties (effect class, constraints).
+- **Deterministic**: Same `psi` → same `PolicyDecision`.
+- **Domain-neutral**: The engine evaluates structure (effect, constraints), not domain semantics.
+
+**Governance over sequences:**
+
+For governance over an entire behaviour sequence V, you would evaluate each trace:
+
+```python
+def evaluate_behaviour(traces: List[ExecutionTrace]) -> bool:
+    """G(V) - governance function over behaviour."""
+    policy_engine = DefaultSafePolicyEngine()
+    
+    for trace in traces:
+        decision = policy_engine.evaluate(trace.psi)
+        if not decision.allowed:
+            return False  # Behaviour violates policy
+    
+    return True  # Behaviour is compliant
+```
+
+---
+
+## 5. L (Boundaries)
+
+### Theory
+
+From `axioms/05_boundaries.md`:
+
+```
+L = g(V)
+
+Boundaries describe which regions of behaviour are permitted or forbidden.
+- Behaviour-derived (computed from V)
+- Non-executing (does not enforce, only describes)
+- Structural (geometry of constraints)
+```
+
+### Implementation
+
+In KL, boundaries are expressed through:
+
+1. **`ExecutionPolicy`** - per-request constraint flags
+2. **`PsiConstraints`** - declarative governance anchors
+3. **`DefaultSafePolicyEngine`** - effect-based safe/unsafe regions
+
+**Example 1: ExecutionPolicy boundaries**
+
+```python
+from kl_kernel_logic import ExecutionPolicy
+
+# Define constraint boundaries
+policy = ExecutionPolicy(
+    allow_network=False,        # Boundary: no external calls
+    allow_filesystem=False,     # Boundary: no IO operations
+    timeout_seconds=5.0         # Boundary: time limit
+)
+
+# These flags describe the allowed region of behaviour
+# Enforcement is separate (in CAEL or orchestrator)
+```
+
+**Example 2: Effect-based boundaries**
+
+```python
+# DefaultSafePolicyEngine defines effect boundaries:
+
+ALLOWED_REGION = {"pure", "read", "ai"}
+FORBIDDEN_REGION = {"io", "external"}
+
+# A PsiDefinition with effect="pure" is inside the allowed region
+# A PsiDefinition with effect="io" is inside the forbidden region
+```
+
+**Example 3: Constraint boundaries**
+
+```python
+from kl_kernel_logic import PsiConstraints
+
+constraints = PsiConstraints(
+    scope="local",              # Boundary: cannot access system-wide state
+    format="json",              # Boundary: must produce JSON output
+    temporal="bounded",         # Boundary: must complete in finite time
+    reversibility="reversible"  # Boundary: must be undoable
+)
+```
+
+**Properties preserved:**
+
+- **Behaviour-derived**: Boundaries are evaluated based on observable properties (effect, constraints, policy flags).
+- **Non-executing**: `ExecutionPolicy` and `PsiConstraints` do not enforce limits themselves. They describe them. Enforcement happens in CAEL or orchestrator.
+- **Structural**: Boundaries define geometry (inside/outside allowed regions), not procedural logic.
+
+**Boundary evaluation over sequences:**
+
+```python
+def evaluate_boundaries(traces: List[ExecutionTrace]) -> Dict[str, Any]:
+    """L(V) - boundary analysis over behaviour."""
+    total_runtime = sum(trace.runtime_ms for trace in traces)
+    effects_used = {trace.psi.effect for trace in traces}
+    
+    return {
+        "total_runtime_ms": total_runtime,
+        "effects_used": effects_used,
+        "within_time_budget": total_runtime < 10000,  # 10s limit
+        "within_effect_boundary": effects_used <= {"pure", "read", "ai"}
+    }
+```
+
+---
+
+## Tests as Proofs
+
+The test suite validates that the implementation preserves the axiom properties:
+
+| Test File | Validates |
+|-----------|-----------|
+| `test_kernel_basic.py` | Δ properties (atomicity, determinism, exception capture) |
+| `test_foundations_flows.py` | V construction (ordered sequences, composition) |
+| `test_runtime_ms.py` | t measurement (timing, logical ordering) |
+| `test_policy_templates.py` | G evaluation (policy decisions, determinism) |
+| `test_constraints.py` | L validation (constraint checking, boundary geometry) |
+| `test_audit_report.py` | Trace capture (completeness, serialization) |
+
+---
+
+## Why This Matters
+
+The alignment between theory and implementation provides:
+
+### 1. Replayability
+
+Since V is a complete ordered sequence of Deltas, and each Delta is deterministic, **the entire execution is replayable**.
+
+### 2. Auditability
+
+Governance can be evaluated **without re-executing** the behaviour.
+
+### 3. Domain Portability
+
+The same abstract structure applies across domains:
+
+- **Finance**: Order = Δ, Order book history = V, Risk check = G, Position limits = L
+- **Biology**: Reaction = Δ, Reaction pathway = V, Conservation law = G, Concentration bounds = L
+- **AI**: Inference = Δ, Inference chain = V, Safety policy = G, Model usage limits = L
+
+KL Kernel Logic provides a **domain-neutral substrate** for all these cases.
+
+### 4. Formal Correctness
+
+The theory provides:
+
+- **Axioms** that define what deterministic execution means
+- **Proofs** that properties like replayability emerge from the axioms
+- **Test suite** that validates implementation preserves axiom properties
+
+This is not accidental design. It's **axiomatic engineering**.
+
+---
+
+## Summary
+
+KL Kernel Logic is a **concrete realization** of KL Execution Theory:
+
+| **Abstraction** | **Realization** |
+|-----------------|-----------------|
+| S (state space) | Python input/output structures |
+| Δ (atomic transition) | `Kernel.execute()` call |
+| V (behaviour) | `List[ExecutionTrace]` |
+| t (logical time) | List index + `runtime_ms` |
+| T (trace) | `ExecutionTrace` object |
+| G (governance) | `PolicyEngine` + evaluation functions |
+| L (boundaries) | `ExecutionPolicy` + `PsiConstraints` |
+
+This is not an implementation detail. It's the **design principle**.
+
+The theory guarantees:
+- Determinism
+- Replayability
+- Auditability
+- Domain neutrality
+
+The code delivers on that guarantee.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kl-kernel-logic"
-version = "0.3.1"
+version = "0.3.3"
 description = "Lightweight deterministic execution substrate for governed operations."
 authors = [
   { name = "Lukas Pfister", email = "228201683+lukaspfisterch@users.noreply.github.com" }

--- a/src/kl_kernel_logic/__init__.py
+++ b/src/kl_kernel_logic/__init__.py
@@ -2,8 +2,20 @@
 KL Kernel Logic core package.
 
 Exposes the fundamental building blocks for defining and executing
-operations in the KL model. This module provides the stable public API
-for Psi definitions, envelopes, execution, policy, and audit.
+operations in the KL model. This package implements the abstract
+KL Execution Theory as concrete Python constructs.
+
+Core axioms → Code mapping:
+  Δ (atomic transitions)  → Kernel.execute()
+  V (behaviour)           → ExecutionTrace sequences
+  t (logical time)        → runtime_ms + trace indices
+  G (governance)          → PolicyEngine evaluation
+  L (boundaries)          → ExecutionPolicy + PsiConstraints
+
+This module provides the stable public API for Psi definitions,
+envelopes, execution, policy, and audit.
+
+See docs/execution_theory_in_code.md for complete correspondence.
 """
 
 # Psi layer

--- a/src/kl_kernel_logic/__init__.py
+++ b/src/kl_kernel_logic/__init__.py
@@ -1,15 +1,16 @@
 """
 KL Kernel Logic core package.
 
-Exposes the main building blocks for defining and executing operations
-under the KL model.
+Exposes the fundamental building blocks for defining and executing
+operations in the KL model. This module provides the stable public API
+for Psi definitions, envelopes, execution, policy, and audit.
 """
 
 # Psi layer
 from .psi import PsiDefinition, PsiConstraints
 from .psi_envelope import PsiEnvelope
 
-# Kernel & CAEL
+# Kernel and CAEL
 from .kernel import Kernel, ExecutionTrace
 from .cael import CAEL, CAELConfig, PolicyViolationError
 
@@ -20,11 +21,11 @@ from .policy import (
     DefaultSafePolicyEngine,
 )
 
+# Execution context
+from .execution_context import ExecutionPolicy, ExecutionContext
+
 # Audit reporting
 from .audit import AuditReport, build_audit_report
-
-# Execution context (identity + per-request constraints)
-from .execution_context import ExecutionPolicy, ExecutionContext
 
 
 __all__ = [
@@ -45,14 +46,13 @@ __all__ = [
     "PolicyEngine",
     "DefaultSafePolicyEngine",
 
-    # Audit
-    "AuditReport",
-    "build_audit_report",
-
     # Execution context
     "ExecutionPolicy",
     "ExecutionContext",
+
+    # Audit
+    "AuditReport",
+    "build_audit_report",
 ]
 
-
-__version__ = "0.3.1"
+__version__ = "0.3.3"

--- a/src/kl_kernel_logic/audit.py
+++ b/src/kl_kernel_logic/audit.py
@@ -1,49 +1,70 @@
 """
-Audit reporting for KL Kernel Logic.
+Audit report model for KL Kernel Logic.
+
+Takes an ExecutionTrace and wraps it into a small, serialisable report
+object that higher-level systems can store or forward.
 """
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any, Dict
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
 
 from .kernel import ExecutionTrace
 
 
-def _utc_timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-
-
-@dataclass(frozen=True)
+@dataclass
 class AuditReport:
     """
-    High level audit view over an execution trace.
+    Minimal audit report.
 
-    It captures:
-    - when the report was generated
-    - a serialised view of the execution trace
+    Attributes:
+        run_id: Identifier of the execution run (mapped from trace_id).
+        trace: Serialised execution trace (ExecutionTrace.describe()).
+        created_at: ISO 8601 timestamp when the run started.
+        metadata: Optional, user-provided metadata.
     """
 
-    generated_at: str
+    run_id: str
     trace: Dict[str, Any]
+    created_at: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def describe(self) -> Dict[str, Any]:
         """
-        Serialisable representation of the audit report.
+        Return a JSON-serialisable representation of the audit report.
+
+        Field names are chosen to be stable for external consumers:
+        - run_id
+        - trace
+        - generated_at  (mapped from created_at)
+        - metadata
         """
         return {
-            "generated_at": self.generated_at,
+            "run_id": self.run_id,
             "trace": self.trace,
+            "generated_at": self.created_at,
+            "metadata": dict(self.metadata),
         }
 
 
-def build_audit_report(trace: ExecutionTrace) -> AuditReport:
+def build_audit_report(
+    trace: ExecutionTrace,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditReport:
     """
-    Build a standard audit report from an ExecutionTrace.
+    Create an AuditReport from a completed ExecutionTrace.
+
+    The report uses:
+      - run_id      := trace.trace_id
+      - created_at  := trace.started_at (fallback: trace.finished_at)
+      - trace       := trace.describe()
+      - metadata    := provided dict or empty
     """
+    report_metadata = metadata or {}
+
+    created_at = trace.started_at or trace.finished_at
     return AuditReport(
-        generated_at=_utc_timestamp(),
+        run_id=trace.trace_id,
         trace=trace.describe(),
+        created_at=created_at,
+        metadata=report_metadata,
     )
-
-
-__all__ = ["AuditReport", "build_audit_report"]

--- a/src/kl_kernel_logic/cael.py
+++ b/src/kl_kernel_logic/cael.py
@@ -1,173 +1,133 @@
 """
-CAEL - Constraint And Execution Layer
+Controlled AI Execution Layer (CAEL).
 
-Thin wrapper around the Kernel for validating Psi, evaluating policies
-and managing envelopes.
+Bridges Psi + Kernel with policy evaluation and optional context handling.
 """
 
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
 
+from .kernel import Kernel, ExecutionTrace
 from .psi import PsiDefinition
 from .psi_envelope import PsiEnvelope
 from .execution_context import ExecutionContext
-from .kernel import Kernel, ExecutionTrace
-from .policy import PolicyEngine, DefaultSafePolicyEngine
+from .policy import PolicyEngine, DefaultSafePolicyEngine, PolicyDecision
 
 
 class PolicyViolationError(Exception):
     """
-    Raised when CAEL blocks execution due to a policy decision.
-    
-    This replaces the old PolicyViolation exception.
+    Raised when a policy engine denies execution of a PsiDefinition.
     """
-    
-    def __init__(self, message: str, policy_name: str, reason: str) -> None:
-        super().__init__(message)
-        self.message = message
+
+    def __init__(self, policy_name: str, reason: str) -> None:
+        super().__init__(f"{policy_name}: {reason}")
         self.policy_name = policy_name
         self.reason = reason
-    
-    def __str__(self) -> str:
-        return f"{self.message} (policy={self.policy_name}, reason={self.reason})"
 
 
-@dataclass(frozen=True)
+@dataclass
 class CAELConfig:
     """
-    Static configuration for CAEL.
+    Configuration for CAEL.
 
-    Kept intentionally small for the core library.
+    Currently:
+      - policy_engine: strategy for policy evaluation
+      - envelope_version: version string for new PsiEnvelope instances
     """
 
-    default_version: str = "1.0"
-    enforce_envelope: bool = False
-    # Policy engine for pre-execution evaluation (defaults to DefaultSafePolicyEngine)
-    policy_engine: Optional[PolicyEngine] = None
-    # Optional default timeout applied when no per-call override or ctx policy present
-    default_timeout_seconds: Optional[int] = None
+    policy_engine: PolicyEngine = DefaultSafePolicyEngine()
+    envelope_version: str = "1.0"
 
 
 class CAEL:
     """
-    Minimal CAEL implementation.
+    Controlled execution entry point.
 
     Responsibilities:
-    - basic Psi validation hook
-    - policy evaluation before execution via PolicyEngine
-    - envelope creation or enrichment
-    - delegation to Kernel
+      - evaluate policies before execution
+      - construct / reuse PsiEnvelope
+      - delegate to Kernel
+      - apply simple timeout classification based on ExecutionContext.policy
     """
 
-    def __init__(self, kernel: Optional[Kernel] = None, config: Optional[CAELConfig] = None) -> None:
-        self.kernel = kernel or Kernel()
+    def __init__(
+        self,
+        config: Optional[CAELConfig] = None,
+        kernel: Optional[Kernel] = None,
+    ) -> None:
         self.config = config or CAELConfig()
-        # Use DefaultSafePolicyEngine if none provided
-        self.policy_engine = self.config.policy_engine or DefaultSafePolicyEngine()
+        self.kernel = kernel or Kernel()
 
     def execute(
         self,
         psi: PsiDefinition,
         task: Callable[..., Any],
-        *,
-        envelope: Optional[PsiEnvelope] = None,
-        metadata: Optional[Dict[str, Any]] = None,
         ctx: Optional[ExecutionContext] = None,
+        envelope: Optional[PsiEnvelope] = None,
         **kwargs: Any,
     ) -> ExecutionTrace:
-        # 1) validation hook
-        self._validate_psi(psi)
+        """
+        Execute a task under the KL model.
 
-        # 2) policy evaluation via PolicyEngine
-        decision = self.policy_engine.evaluate(psi)
-        if not decision.allowed:
-            raise PolicyViolationError(
-                message="Execution blocked by policy",
-                policy_name=decision.policy_name,
-                reason=decision.reason,
-            )
+        Steps:
+          1. Policy evaluation (may raise PolicyViolationError)
+          2. Envelope construction (if not provided)
+          3. Kernel execution
+          4. Attach policy decision to trace
+          5. Classify timeouts based on ExecutionContext.policy.timeout_seconds
+        """
 
-        # Legacy per-call control flags adapter (backwards compatibility)
-        # If callers pass explicit flags like `needs_fs` or `needs_network`,
-        # honour them against the provided ExecutionContext.policy where available
-        if ctx is not None:
-            if kwargs.get("needs_network") and not ctx.policy.allow_network:
+        # 1. Policy evaluation
+        decision: Optional[PolicyDecision] = None
+        if self.config.policy_engine is not None:
+            decision = self.config.policy_engine.evaluate(psi)
+            if not decision.allowed:
                 raise PolicyViolationError(
-                    message="Operation requires network access but policy forbids it",
-                    policy_name="execution_context",
-                    reason="needs_network flag set but allow_network=False"
-                )
-            if kwargs.get("needs_fs") and not ctx.policy.allow_filesystem:
-                raise PolicyViolationError(
-                    message="Operation requires filesystem access but policy forbids it",
-                    policy_name="execution_context",
-                    reason="needs_fs flag set but allow_filesystem=False"
+                    decision.policy_name,
+                    decision.reason or "policy denied execution",
                 )
 
-        # 3) context metadata
-        ctx_meta: Dict[str, Any] = {}
-        if ctx is not None:
-            ctx_meta = {
-                "user_id": ctx.user_id,
-                "request_id": ctx.request_id,
-                "policy": {
-                    "allow_network": ctx.policy.allow_network,
-                    "allow_filesystem": ctx.policy.allow_filesystem,
-                    "timeout_seconds": ctx.policy.timeout_seconds,
-                    "max_tokens": ctx.policy.max_tokens,
-                },
-            }
+        # 2. Envelope construction
+        env = envelope or PsiEnvelope(
+            psi=psi,
+            version=self.config.envelope_version,
+        )
 
-        combined_meta: Dict[str, Any] = {}
-        if metadata:
-            combined_meta.update(metadata)
-        if ctx_meta:
-            combined_meta.update(ctx_meta)
+        # 3. Kernel execution (no policy kwargs forwarded to task)
+        trace = self.kernel.execute(
+            psi=psi,
+            task=task,
+            envelope=env,
+            **kwargs,
+        )
 
-        # 4) envelope handling
-        if envelope is None:
-            envelope = PsiEnvelope(
-                psi=psi,
-                version=self.config.default_version,
-                metadata=combined_meta or None,
-            )
-        elif combined_meta:
-            merged = dict(envelope.metadata or {})
-            merged.update(combined_meta)
-            envelope = PsiEnvelope(
-                psi=envelope.psi,
-                version=envelope.version,
-                envelope_id=envelope.envelope_id,
-                timestamp=envelope.timestamp,
-                metadata=merged,
-                signature=envelope.signature,
+        # 4. Attach policy decision to trace (if available)
+        if decision is not None:
+            trace.policy_decisions.append(
+                {
+                    "policy_name": decision.policy_name,
+                    "allowed": decision.allowed,
+                    "reason": decision.reason,
+                }
             )
 
-        # 5) delegate to kernel
-        # Determine timeout precedence (highest -> lowest):
-        #  - explicit per-call kwarg `timeout_seconds`
-        #  - ExecutionContext.policy.timeout_seconds (per-request)
-        #  - CAELConfig.default_timeout_seconds (global default)
-        timeout = None
-        # allow explicit per-call override
-        if "timeout_seconds" in kwargs:
-            timeout = kwargs.pop("timeout_seconds")
-        if timeout is None and ctx is not None:
-            timeout = ctx.policy.timeout_seconds
-        if timeout is None:
-            timeout = self.config.default_timeout_seconds
+        # 5. Timeout classification (post-hoc, based on measured runtime)
+        timeout_seconds: Optional[float] = None
+        if ctx is not None and ctx.policy is not None:
+            timeout_seconds = ctx.policy.timeout_seconds
 
-        trace = self.kernel.execute(psi=psi, task=task, envelope=envelope, timeout_seconds=timeout, **kwargs)
+        if (
+            timeout_seconds is not None
+            and trace.runtime_ms is not None
+            and trace.runtime_ms > timeout_seconds * 1000.0
+        ):
+            timeout_message = (
+                f"TimeoutError: execution exceeded {timeout_seconds} seconds"
+            )
+            if trace.error:
+                trace.error = f"{timeout_message}; original error: {trace.error}"
+            else:
+                trace.error = timeout_message
+            trace.success = False
+
         return trace
-
-    def _validate_psi(self, psi: PsiDefinition) -> None:
-        """
-        Hook for structural or policy based Psi validation.
-
-        Left intentionally as a no-op in the core package and can be
-        extended in higher level integrations.
-        """
-        return
-
-
-__all__ = ["CAELConfig", "CAEL", "PolicyViolationError"]

--- a/src/kl_kernel_logic/execution_context.py
+++ b/src/kl_kernel_logic/execution_context.py
@@ -1,53 +1,113 @@
 """
-Execution context and policy helpers for KL Kernel Logic.
+Execution context and per-request policy flags.
 
-These types provide a structured way to describe who triggers an
-operation and under which execution policy it should run.
-
-They are deliberately kept light weight so they can be used by
-orchestrators, CLIs or services without constraining the core kernel.
+The context attaches identity and lightweight execution policy
+to a single CAEL/Kernel run.
 """
 
-from dataclasses import dataclass
-from typing import Optional
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
 
 
 @dataclass(frozen=True)
 class ExecutionPolicy:
     """
-    Declarative execution policy used by higher level components.
+    Minimal per-request policy flags.
 
-    Typical usage:
-        policy = ExecutionPolicy(
-            allow_network=False,
-            allow_filesystem=False,
-            timeout_seconds=5,
-        )
-
-    The kernel itself does not enforce these flags. They are intended
-    for CAEL, orchestrators or adapters that interpret and enforce them.
+    These flags can be inspected by PolicyEngine implementations or
+    by CAEL to derive execution behavior (for example timeouts).
     """
 
     allow_network: bool = False
     allow_filesystem: bool = False
-    timeout_seconds: int = 30
-    max_tokens: Optional[int] = None
+    timeout_seconds: Optional[float] = None
+
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize policy to a plain dict for logging or transport.
+        """
+        return {
+            "allow_network": self.allow_network,
+            "allow_filesystem": self.allow_filesystem,
+            "timeout_seconds": self.timeout_seconds,
+            "metadata": dict(self.metadata),
+        }
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "ExecutionPolicy":
+        """
+        Rebuild an ExecutionPolicy from a dict representation.
+
+        If data is None, a default policy is returned.
+        """
+        if data is None:
+            return ExecutionPolicy()
+
+        return ExecutionPolicy(
+            allow_network=bool(data.get("allow_network", False)),
+            allow_filesystem=bool(data.get("allow_filesystem", False)),
+            timeout_seconds=data.get("timeout_seconds"),
+            metadata=dict(data.get("metadata", {})),
+        )
 
 
-@dataclass(frozen=True)
+@dataclass
 class ExecutionContext:
     """
-    Execution context for a single operation run.
+    Execution context for a single request.
 
-    Captures:
-    - user_id: logical caller identity
-    - request_id: id for tracing and correlation
-    - policy: associated ExecutionPolicy
+    Carries:
+      - user_id: logical identity of the caller
+      - request_id: id for correlation and tracing
+      - policy: optional ExecutionPolicy (per-request overrides)
+      - metadata: free-form context information
     """
 
     user_id: str
     request_id: str
-    policy: ExecutionPolicy
 
+    policy: Optional[ExecutionPolicy] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
-__all__ = ["ExecutionPolicy", "ExecutionContext"]
+    def policy_or_default(self) -> ExecutionPolicy:
+        """
+        Return the attached policy or a default instance.
+
+        This is safe to call from CAEL and policy adapters without
+        needing to check for None.
+        """
+        if self.policy is not None:
+            return self.policy
+        return ExecutionPolicy()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the context to a dict for logging or transport.
+        """
+        return {
+            "user_id": self.user_id,
+            "request_id": self.request_id,
+            "policy": self.policy.to_dict() if self.policy is not None else None,
+            "metadata": dict(self.metadata),
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ExecutionContext":
+        """
+        Rebuild an ExecutionContext from a dict representation.
+        """
+        policy_data = data.get("policy")
+        policy = (
+            ExecutionPolicy.from_dict(policy_data) if policy_data is not None else None
+        )
+
+        return ExecutionContext(
+            user_id=str(data["user_id"]),
+            request_id=str(data["request_id"]),
+            policy=policy,
+            metadata=dict(data.get("metadata", {})),
+        )

--- a/src/kl_kernel_logic/policy.py
+++ b/src/kl_kernel_logic/policy.py
@@ -1,99 +1,61 @@
-from __future__ import annotations
+"""
+Policy system for KL Kernel Logic.
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+Minimal interface + default policy implementation.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .psi import PsiDefinition
 
 
-@dataclass(frozen=True)
+@dataclass
 class PolicyDecision:
     """
-    A single policy decision entry.
-
-    It records:
-    - policy_name: which policy evaluated the Psi
-    - allowed: whether execution is allowed
-    - reason: short human-readable explainability field
-    - metadata: optional extra data
+    Result of a policy evaluation for a given PsiDefinition.
     """
 
     policy_name: str
     allowed: bool
-    reason: str
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-    def describe(self) -> Dict[str, Any]:
-        return {
-            "policy_name": self.policy_name,
-            "allowed": self.allowed,
-            "reason": self.reason,
-            "metadata": dict(self.metadata),
-        }
+    reason: Optional[str] = None
 
 
 class PolicyEngine:
     """
-    Base policy engine interface for KL.
+    Abstract policy evaluation interface.
 
-    Later versions can dispatch multiple policies, but KL 0.3.0
-    only requires a single default policy.
+    Implementations decide whether a given PsiDefinition is allowed to execute.
     """
 
-    def evaluate(self, psi) -> PolicyDecision:
-        """
-        Evaluate the PsiDefinition and return a PolicyDecision.
-
-        Must be overridden by concrete implementations.
-        """
-        raise NotImplementedError
+    def evaluate(self, psi: PsiDefinition) -> PolicyDecision:
+        raise NotImplementedError("PolicyEngine.evaluate() must be implemented")
 
 
 class DefaultSafePolicyEngine(PolicyEngine):
     """
-    Minimal safe policy for KL 0.3.0.
+    Effect-based default policy.
 
-    Rules:
-    - effect="pure" is always allowed
-    - effect="read" is allowed (configuration/lookup)
-    - effect="io" is blocked
-    - effect="external" is blocked
-    - effect="ai" is allowed (but marked as nondeterministic placeholder)
+    Semantics:
+      - allow:   effect in {"pure", "read", "ai"}
+      - deny:    effect in {"io", "external"} or anything else
     """
 
-    def evaluate(self, psi) -> PolicyDecision:
-        effect = psi.effect
+    def evaluate(self, psi: PsiDefinition) -> PolicyDecision:
+        effect = (psi.effect or "").strip().lower()
+        # Stable, test-friendly policy name
+        policy_name = "default_safe_policy"
 
-        # Rule set
-        if effect == "pure":
+        if effect in {"pure", "read", "ai"}:
             return PolicyDecision(
-                policy_name="default_safe",
+                policy_name=policy_name,
                 allowed=True,
-                reason="pure operation",
+                reason=f"effect '{effect}' is allowed under {policy_name}",
             )
 
-        if effect == "read":
-            return PolicyDecision(
-                policy_name="default_safe",
-                allowed=True,
-                reason="read-only operation",
-            )
-
-        if effect in {"io", "external"}:
-            return PolicyDecision(
-                policy_name="default_safe",
-                allowed=False,
-                reason=f"effect '{effect}' is not allowed under DefaultSafePolicyEngine",
-            )
-
-        if effect == "ai":
-            return PolicyDecision(
-                policy_name="default_safe",
-                allowed=True,
-                reason="ai operation (nondeterministic allowed placeholder)",
-            )
-
-        # Fallback
+        # Block everything else (including "io" and "external")
         return PolicyDecision(
-            policy_name="default_safe",
+            policy_name=policy_name,
             allowed=False,
-            reason=f"unknown effect type '{effect}'",
+            reason=f"effect '{effect}' is not allowed under {policy_name}",
         )

--- a/src/kl_kernel_logic/psi_envelope.py
+++ b/src/kl_kernel_logic/psi_envelope.py
@@ -1,10 +1,3 @@
-"""
-Psi Envelope
-
-Minimal, versioned container for transporting Psi definitions
-through Kernel, CAEL, orchestrators and audit layers.
-"""
-
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -12,47 +5,68 @@ from uuid import uuid4
 
 from .psi import PsiDefinition
 
+"""
+Psi envelope layer for KL Kernel Logic.
 
-def _utc_timestamp() -> str:
+PsiEnvelope is a transparent, versioned transport container for PsiDefinition.
+It adds identifiers and timestamps required for traceability and audit.
+"""
+
+
+def _utc_now_iso() -> str:
     """
-    Return an ISO 8601 UTC timestamp with millisecond precision and trailing Z.
+    Return current UTC time as an ISO 8601 string.
     """
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat()
 
 
 @dataclass(frozen=True)
 class PsiEnvelope:
     """
-    Transparent, deterministic container carrying a PsiDefinition.
+    Versioned transport container for Psi definitions.
 
     Fields:
-    - psi: the PsiDefinition being executed
-    - version: schema or contract version
-    - envelope_id: unique id for traceability and correlation
-    - timestamp: ISO 8601 creation time (UTC, with trailing Z)
-    - metadata: optional free form key value pairs for routing and audit
-    - signature: optional signature representation
+    - psi:         the declarative PsiDefinition
+    - version:     schema version of the envelope
+    - envelope_id: unique identifier for this envelope
+    - timestamp:   creation time in ISO 8601 (UTC)
+    - metadata:    optional free-form metadata
+    - signature:   optional external signature or checksum
     """
 
     psi: PsiDefinition
-    version: str
+    version: str = "0.3.3"
     envelope_id: str = field(default_factory=lambda: str(uuid4()))
-    timestamp: str = field(default_factory=_utc_timestamp)
-    metadata: Optional[Dict[str, Any]] = None
+    timestamp: str = field(default_factory=_utc_now_iso)
+    metadata: Dict[str, Any] = field(default_factory=dict)
     signature: Optional[str] = None
 
     def describe(self) -> Dict[str, Any]:
         """
-        Return a serialisable representation used by Kernel, CAEL and audit logs.
+        Human/audit oriented representation of this envelope.
+
+        For now, identical to to_dict(), but kept as a separate method
+        for compatibility with ExecutionTrace.describe().
         """
+        return self.to_dict()
+
+    def to_dict(self) -> Dict[str, Any]:
         return {
+            "psi": self.psi.describe(),
             "version": self.version,
             "envelope_id": self.envelope_id,
             "timestamp": self.timestamp,
-            "psi": self.psi.describe(),
-            "metadata": self.metadata or {},
+            "metadata": dict(self.metadata),
             "signature": self.signature,
         }
 
-
-__all__ = ["PsiEnvelope"]
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PsiEnvelope":
+        return cls(
+            psi=PsiDefinition.from_dict(data["psi"]),
+            version=data.get("version", "0.3.3"),
+            envelope_id=data.get("envelope_id", str(uuid4())),
+            timestamp=data.get("timestamp") or _utc_now_iso(),
+            metadata=dict(data.get("metadata") or {}),
+            signature=data.get("signature"),
+        )


### PR DESCRIPTION
This merges the validated 0.3.3 minimal deterministic core into main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors to a minimal 0.3.3 core: simplify Kernel/CAEL (no multiprocessing timeouts), tighten policy/context/audit/psi/envelope APIs, add execution-theory docs, and update README.
> 
> - **Core (Kernel/CAEL)**
>   - Simplify `Kernel.execute()` to single-process execution; remove multiprocessing-based timeouts; add precise `runtime_ms` via `perf_counter`.
>   - `ExecutionTrace` reshaped (required `runtime_ms`, `parent_trace_id`, `policy_decisions`, `metadata`); stable `describe()` output.
>   - `CAEL` refactored: policy pre-check with `PolicyViolationError`, auto-build `PsiEnvelope`, attach policy decisions, and post-hoc timeout classification from `ExecutionContext.policy.timeout_seconds`.
> - **Policy & Context**
>   - Streamlined `PolicyDecision` (optional `reason`) and renamed default policy to `default_safe_policy`; allow `pure|read|ai`, deny `io|external`.
>   - `ExecutionPolicy`/`ExecutionContext` revamped: optional policy, Optional[float] timeouts, metadata, and `to_dict`/`from_dict` helpers.
> - **Audit**
>   - New `AuditReport` shape: `run_id`, `trace`, `created_at`, optional `metadata`; `build_audit_report` accepts metadata and derives IDs/timestamps from trace.
> - **Psi & Envelope**
>   - `PsiDefinition` default `version="0.3.3"`; `describe()` → `to_dict()`; add `from_dict()`; updated constraint domains; `PsiConstraints` gets `to_dict()`/`from_dict()`.
>   - `PsiEnvelope` defaults (`version="0.3.3"`, ISO UTC timestamp), `metadata` default dict, `to_dict()`/`from_dict()`.
> - **Docs**
>   - Add `docs/execution_theory_in_code.md` mapping Δ/V/t/G/L to code.
>   - README rewritten: tighter overview, updated examples, policy/audit sections, license link fixed.
> - **Version**
>   - Bump package/version exports to `0.3.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791fab260741dcb772aafe8e6faa5c5c9ebbcbfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->